### PR TITLE
Don't self-register brains

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ LIBFILES   = $(shell git ls-files lib)
 BINFILES   = $(shell git ls-files bin script)
 TFILES     = $(shell git ls-files t)
 OTHERFILES = cpanfile
+ifeq ($(NOCACHE), 1)
+	override NOCACHE = --no-cache
+endif
 
 clean:
 	dzil clean
@@ -12,7 +15,10 @@ OpusVL-FB11-%.tar.gz: $(LIBFILES) $(BINFILES) $(TFILES) $(OTHERFILES)
 	dzil build
 dist: OpusVL-FB11-$(version).tar.gz
 docker: dist
-	docker build \
+	docker build $(NOCACHE) \
 		--build-arg version=`dzil distversion` \
 		--build-arg gitrev="`set -x ; git rev-parse HEAD ; git status ; git diff`" \
 		-t quay.io/opusvl/fb11:latest .
+ifeq ($(PUSH), 1)
+	docker push quay.io/opusvl/fb11:latest
+endif

--- a/lib/OpusVL/FB11/Controller/FB11/Admin/Users.pm
+++ b/lib/OpusVL/FB11/Controller/FB11/Admin/Users.pm
@@ -218,7 +218,7 @@ sub show_user
             }
 
             $c->flash->{status_msg} = "Successfully updated parameters";
-            $c->res->redirect($c->req->ur
+            $c->res->redirect($c->req->uri);
         }
     }
 

--- a/lib/OpusVL/FB11/Controller/FB11/Admin/Users.pm
+++ b/lib/OpusVL/FB11/Controller/FB11/Admin/Users.pm
@@ -233,7 +233,7 @@ sub show_user
                 data      => $upload->slurp,
             });
             $c->flash->{status_msg} = "Successfully updated avatar";
-            $c->res->redirect($c->req->ur
+            $c->res->redirect($c->req->uri);
         }
     }
 

--- a/lib/OpusVL/FB11/Controller/FB11/Admin/Users.pm
+++ b/lib/OpusVL/FB11/Controller/FB11/Admin/Users.pm
@@ -169,9 +169,12 @@ sub show_user
 
     # TODO - this is probably more useful done elsewhere
     my $params_form_config = {};
+    HAT:
     for my $hat (OpusVL::FB11::Hive->hats('parameters')) {
         if (elem 'OpusVL::FB11::Schema::FB11AuthDB::Result::User', [$hat->get_augmented_classes]) {
             my $schema =  $hat->get_parameter_schema;
+            next HAT if not $schema or not %$schema;
+
             my $field_config = OpusVL::FB11::Form->openapi_to_formhandler($schema);
             my $fieldset = {
                 name => $schema->{'x-namespace'},

--- a/lib/OpusVL/FB11/Controller/FB11/Admin/Users.pm
+++ b/lib/OpusVL/FB11/Controller/FB11/Admin/Users.pm
@@ -5,6 +5,10 @@ use namespace::autoclean;
 use String::MkPasswd qw/mkpasswd/;
 use Data::Munge qw/elem/;
 use Try::Tiny;
+use List::Util qw/pairkeys/;
+
+use OpusVL::FB11::Form;
+use OpusVL::FB11::Hive;
 
 BEGIN { extends 'Catalyst::Controller'; };
 with 'OpusVL::FB11::RolesFor::Controller::GUI';
@@ -163,6 +167,57 @@ sub show_user
     $form->process($c->req->params);
     $upload_form->process($c->req->params);
 
+    # TODO - this is probably more useful done elsewhere
+    my $params_form_config = {};
+    for my $hat (OpusVL::FB11::Hive->hats('parameters')) {
+        if (elem 'OpusVL::FB11::Schema::FB11AuthDB::Result::User', [$hat->get_augmented_classes]) {
+            my $schema =  $hat->get_parameter_schema;
+            my $field_config = OpusVL::FB11::Form->openapi_to_formhandler($schema);
+            my $fieldset = {
+                name => $schema->{'x-namespace'},
+                tag => 'fieldset',
+                label => $schema->{title},
+                render_list => [ pairkeys @$field_config ],
+            };
+
+            push $params_form_config->{field_list}->@*, @$field_config;
+            push $params_form_config->{block_list}->@*, $fieldset;
+            push $params_form_config->{render_list}->@*, $fieldset->{name};
+            $params_form_config->{init_object} //= {};
+            $params_form_config->{init_object} = {
+                $params_form_config->{init_object}->%*,
+                OpusVL::FB11::Form->openapi_to_init_object(
+                    $schema,
+                    $hat->get_augmented_data($c->stash->{thisuser})
+                )
+                ->%*
+            };
+        }
+    }
+
+    if (%$params_form_config) {
+        push $params_form_config->{field_list}->@*, (
+            submit_params => 'Submit'
+        );
+        push $params_form_config->{render_list}->@*, 'submit_params';
+
+        my $params_form = $c->stash->{params_form} = OpusVL::FB11::Form->new($params_form_config);
+        $params_form->process($c->req->params);
+        if ($params_form->validated) {
+            for my $hat (OpusVL::FB11::Hive->hats('parameters')) {
+                my $schema =  $hat->get_parameter_schema;
+                if (elem 'OpusVL::FB11::Schema::FB11AuthDB::Result::User', [$hat->get_augmented_classes]) {
+                    $hat->set_augmented_data(
+                        $c->stash->{thisuser},
+                        $params_form->params_back_to_openapi( $schema )
+                    )
+                }
+            }
+
+            $c->flash->{status_msg} = "Successfully updated parameters";
+            $c->res->redirect($c->req->ur
+        }
+    }
 
     if (my $upload = $c->req->upload('file')) {
         my @params = ( file => $upload );
@@ -175,11 +230,11 @@ sub show_user
                 data      => $upload->slurp,
             });
             $c->flash->{status_msg} = "Successfully updated avatar";
-            $c->res->redirect($c->req->uri);
+            $c->res->redirect($c->req->ur
         }
     }
 
-    if ($form->validated) {   
+    if ($form->validated) {
         my $user_roles = $form->field('user_roles')->value;
         if (@$user_roles) {
             foreach my $role(@$user_roles) {

--- a/lib/OpusVL/FB11/Form.pm
+++ b/lib/OpusVL/FB11/Form.pm
@@ -1,0 +1,176 @@
+package OpusVL::FB11::Form;
+
+use v5.24;
+use OpusVL::FB11::Plugin::FormHandler;
+
+our $VERSION = "0.001";
+
+# ABSTRACT: Place to hold form-based functions
+
+=head1 DESCRIPTION
+
+This is an empty form that can be used to create an FB11 form from a field list,
+without having to create a new class for it.
+
+It also has class methods for constructing forms.
+
+=head1 CLASS METHODS
+
+=head2 new_from_openapi
+
+B<Arguments>: C<%$schema>, C<%$hfh_args>?
+
+Creates a new form from an OpenAPI schema object. This just defers to
+L</openapi_to_formhandler> and uses the result as the C<field_list> of a new
+form.
+
+You can also supply the rest of the options to HTML::FormHandler->new in the
+second parameter, including another C<field_list>, which will be added I<before>
+the fields from the schema.
+
+=cut
+
+sub new_from_openapi {
+    my $class = shift;
+    my $schema = shift;
+    my $hfh_args = shift || {};
+
+    my $field_list = $class->openapi_to_formhandler($schema);
+
+    if (my $to_merge = $hfh_args->{field_list}) {
+        $field_list = [ @$to_merge, @$field_list ];
+    }
+
+    $hfh_args->{field_list} = $field_list;
+
+    return $class->new($hfh_args);
+}
+
+=head2 openapi_to_formhandler
+
+B<Arguments>: C<%$openapi_schema>
+
+B<Returns>: C<@%formhandler_fields>
+
+Converts the OpenAPI Schema object into a FormHandler field definition arrayref.
+
+=cut
+
+sub openapi_to_formhandler {
+    my $class = shift;
+    my $schema = shift;
+
+    # TODO - this could become very complicated. Eventually we will be wanting
+    # to add custom field types to this array so that the form validates the
+    # openapi spec.
+    # It might be better to create a suite of fields for formhandler that work
+    # with the openapi spec.
+    my $formhandler = [];
+
+    my $order = $schema->{'x-field-order'} // [ sort keys $schema->{properties}->%* ];
+
+    my $namespace = $schema->{'x-namespace'} // '';
+    $namespace .= '_' if $namespace;
+
+    for my $field (@$order) {
+        my $def = $schema->{properties}->{$field};
+        push @$formhandler, (
+            $namespace . _to_field_name($field) => {
+                type => _to_field_type($def->{type}),
+                label => $def->{title} // $field,
+                # TODO validation
+            }
+        )
+    }
+
+    return $formhandler;
+}
+
+=head2 openapi_to_init_object
+
+B<Arguments>: C<%$openapi_schema>, C<%$init_object>
+
+Given the same schema you might pass to L</openapi_to_formhandler>, converts an
+object that conforms to that schema into an object that can be used as the
+C<init_object> for a FormHandler form.
+
+This is a way of translating field names.
+
+=cut
+
+sub openapi_to_init_object {
+    my $class = shift;
+    my $schema = shift;
+    my $init_object = shift;
+
+    my $output_object = shift;
+
+    my $namespace = $schema->{'x-namespace'} // '';
+    $namespace .= '_' if $namespace;
+
+    return {
+        map {
+            $namespace . _to_field_name($_) => $init_object->{$_}
+        }
+        keys %$init_object
+    }
+}
+
+=head1 METHODS
+
+Intended to be run on the object, not the class
+
+=head2 params_back_to_openapi
+
+B<Arguments>: C<%$openapi_schema>
+
+B<Returns>: C<%$compliant_hashref>
+
+Given that we converted an OpenAPI schema to a form using its namespace and
+sanitised field names, this will pluck those field names out of the form and
+produce an object that conforms to the schema.
+
+Due to the fact we munged the field names in the first place, it is not entirely
+guaranteed that this process is reversible; but it should be. Problems are the
+responsibility of the schema creator.
+
+=cut
+
+sub params_back_to_openapi {
+    my $self = shift;
+    my $schema = shift;
+
+    my $namespace = $schema->{'x-namespace'} // '';
+    $namespace .= '_' if $namespace;
+
+    my $ret = {};
+
+    for my $field (keys $schema->{properties}->%*) {
+        my $form_field = $namespace . _to_field_name($field);
+
+        $ret->{$field} = $self->field($form_field)->value;
+    }
+
+    return $ret;
+}
+
+# sanitises the field name into lowercase_underscore
+sub _to_field_name {
+    my $badname = shift;
+    return lc $badname =~ s/^\s+|\s+$//gr =~ s/\s+/_/gr;
+}
+
+# Returns an appropriate FormHandler field type for the OpenAPI type
+{
+    my %mapping = (
+        string => 'Text',
+    );
+
+    sub _to_field_type {
+        my $openapi_name = shift;
+        # TODO
+        return $mapping{$openapi_name} || die "I don't know how to render $openapi_name";
+    }
+}
+
+1;

--- a/lib/OpusVL/FB11/Hive.pm
+++ b/lib/OpusVL/FB11/Hive.pm
@@ -112,10 +112,10 @@ sub hats {
 
     # TODO: Interrogate this config information when a brain is registered.
     return gather {
-        for my $b (values %brains) {
-            my %config = $self->_consume_hat_config($b->hats);
+        for my $br (values %brains) {
+            my %config = $self->_consume_hat_config($br->hats);
 
-            take $b->hat($hat_name) if $config{$hat_name};
+            take $br->hat($hat_name) if $config{$hat_name};
         }
     }
 }

--- a/lib/OpusVL/FB11/Role/Brain.pm
+++ b/lib/OpusVL/FB11/Role/Brain.pm
@@ -206,9 +206,7 @@ sub provided_services {}
 
 =head2 register_self
 
-Call this if your Brain isn't a normal Moose class. By default, the Role hooks
-into BUILD and registers itself after construction, but packages are not
-required to provide a C<sub new>, such as DBIx::Class::Schema.
+Syntactic sugar for self-installing into the hive.
 
 =cut
 
@@ -216,9 +214,5 @@ sub register_self {
     my $self = shift;
     OpusVL::FB11::Hive->register_brain($self);
 }
-
-# This ensures there *is* a BUILD, and has no effect if there already is one.
-sub BUILD {}
-after BUILD => \&register_self;
 
 1;

--- a/lib/OpusVL/FB11/Role/Hat/parameters.pm
+++ b/lib/OpusVL/FB11/Role/Hat/parameters.pm
@@ -190,7 +190,13 @@ around get_augmented_data => sub {
 
     my $obj = shift;
 
-    return unless elem ref $obj, [ $self->get_augmented_classes ];
+#    FIXME - Catalyst gives me the wrong class name for $c->user!
+#    It uses AppName::Model::FB11AuthDB::User
+#    When we figure out how to call it on the real class, we can do this.
+#    unless (elem ref $obj, [ $self->get_augmented_classes ]) {
+#        warn ref($self) . " does not have parameters for " . ref($obj);
+#        return;
+#    }
 
     return $self->$orig($obj, @_);
 };

--- a/lib/OpusVL/FB11/Role/Hat/parameters.pm
+++ b/lib/OpusVL/FB11/Role/Hat/parameters.pm
@@ -1,6 +1,7 @@
 package OpusVL::FB11::Role::Hat::parameters;
 
 use Moose::Role;
+with 'OpusVL::FB11::Role::Hat';
 
 # ABSTRACT: Defines the required methods for a parameters service provider
 

--- a/lib/OpusVL/FB11/Role/Hat/parameters.pm
+++ b/lib/OpusVL/FB11/Role/Hat/parameters.pm
@@ -90,6 +90,9 @@ B<Arguments>: C<$data>
 C<$data> will be an arbitrary object, and the implementer must return the
 parameters for it.
 
+Best practice is to return a hashref of data that conforms to
+L</get_parameter_schema>, to ensure consistency and establish a standard.
+
 =cut
 
 requires 'get_augmented_data';
@@ -111,7 +114,16 @@ C<$class> will be a class returned by L</get_augmented_classes>. The implementer
 must return a data structure that defines the user-defined schema for the
 parameters for this class.
 
-The shape of this schema is TBC but it probably will be a subset of OpenAPI.
+The schema should be an OpenAPI Schema object.
+
+B<Extensions> The OpenAPI schema object can be extended with:
+
+C<x-namespace>: A namespace for the fields so we can identify your fields later,
+if multiple parameters schemata are going into the same form. It is a good idea
+to use this.
+
+C<x-field-order>: An array of field names (not namespaced) to control the
+expected ordering of your parameters, if you want.
 
 =cut
 

--- a/lib/OpusVL/FB11/Schema/FB11AuthDB.pm
+++ b/lib/OpusVL/FB11/Schema/FB11AuthDB.pm
@@ -14,7 +14,7 @@ has short_name => (
 );
 
 sub hats {
-    qw/auth/;
+    qw/auth parameters/;
 }
 
 sub provided_services {

--- a/lib/OpusVL/FB11/Schema/FB11AuthDB/Hat/parameters.pm
+++ b/lib/OpusVL/FB11/Schema/FB11AuthDB/Hat/parameters.pm
@@ -1,0 +1,144 @@
+package OpusVL::FB11::Schema::FB11AuthDB::Hat::parameters;
+
+# ABSTRACT: Provides an interface to the legacy user parameters
+
+=head1 DESCRIPTION
+
+The FB11AuthDB has vestigial traces of the old AppKitAuthDB in the
+UsersParameter result class.
+
+Rather than acknowledging this specifically, we provide this interface to allow
+the users page to ask anything whether it has an augmentation for that page, and
+this will respond if appropriate.
+
+This will only really work if the brain that wears it is the FB11AuthDB itself.
+
+=cut
+
+our $VERSION = "0.001";
+use Moose;
+with 'OpusVL::FB11::Role::Hat::parameters';
+
+my $_oapi_equivalent_of = {
+    text => {
+        type => 'string',
+    },
+    number => {
+        type => 'number',
+    },
+    float => {
+        type => 'number',
+        format => 'float',
+    },
+    boolean => {
+        type => 'boolean',
+    },
+};
+
+=head1 METHODS
+
+=head2 get_augmented_data
+
+Returns a hashref that matches L</get_parameter_schema>, or undef.
+
+=cut
+
+sub get_augmented_data {
+    my $self = shift;
+    my $user = shift;
+    my $resultset = $self->__brain->resultset('UsersParameter')
+        ->search({ users_id => $user->id });
+
+    return {
+        map { $_->parameter->parameter => $_->value } $resultset->all
+    }
+}
+
+=head2 get_augmented_classes
+
+Only C<OpusVL::FB11::Schema::FB11AuthDB::Result::User> is augmented by this hat.
+
+=cut
+
+sub get_augmented_classes {
+    qw/OpusVL::FB11::Schema::FB11AuthDB::Result::User/
+}
+
+=head2 get_parameter_schema
+
+Returns an OpenAPI schema object that digests the defined user parameters. They
+only have a type, and maybe a default.
+
+=cut
+
+sub get_parameter_schema {
+    my $self = shift;
+    my $parameters = $self->__brain->resultset('Parameter')->search({}, { order_by => 'parameter' });
+
+    my $schema = {
+        title => "Legacy Parameters",
+        type => 'object',
+        'x-field-order' => [],
+        'x-namespace' => $self->__brain->short_name,
+    };
+
+    for my $param ($parameters->all) {
+        $schema->{properties}->{$param->parameter} = $_oapi_equivalent_of->{$param->data_type};
+        push $schema->{'x-field-order'}->@*, $param->parameter;
+
+        # I do not know why this is a has_many
+        if (my $default = $param->parameter_defaults->first) {
+            $schema->{properties}->{$param->parameter}->{default} = $default->data;
+        }
+    }
+
+    return $schema;
+}
+
+=head2 set_augmented_data
+
+Receives a user object and an OpenAPI-compliant hashref and sets the values.
+
+That's a posh way of saying, pass a User and a hashref of data.
+
+=cut
+
+sub set_augmented_data {
+    my $self = shift;
+    my $user = shift;
+    my $hashref = shift;
+
+    my $param_rs = $self->__brain->resultset('Parameter');
+    my $user_param_rs = $self->__brain->resultset('UsersParameter');
+
+    for my $param (keys %$hashref) {
+        my $param_obj = $param_rs->find({ parameter => $param });
+        my $user_param = $user_param_rs->find_or_create({
+            users_id => $user->id,
+            parameter_id => $param_obj->id,
+
+        });
+        $user_param->update({
+            value => $hashref->{$param}
+        });
+    }
+}
+
+=head2 set_parameter_schema
+
+Cannot be used. This is a readonly compatibility module.
+
+=cut
+
+sub set_parameter_schema {
+    die "Legacy user parameters are DEPRECATED and cannot be used this way.";
+}
+
+sub register_extension{}
+
+sub _oapi_equivalent_of {
+    my $type = shift;
+
+    
+}
+1;

--- a/lib/OpusVL/FB11/Schema/FB11AuthDB/Hat/parameters.pm
+++ b/lib/OpusVL/FB11/Schema/FB11AuthDB/Hat/parameters.pm
@@ -136,9 +136,4 @@ sub set_parameter_schema {
 
 sub register_extension{}
 
-sub _oapi_equivalent_of {
-    my $type = shift;
-
-    
-}
 1;

--- a/lib/OpusVL/FB11/Schema/FB11AuthDB/Result/User.pm
+++ b/lib/OpusVL/FB11/Schema/FB11AuthDB/Result/User.pm
@@ -210,22 +210,32 @@ sub augmentation_for {
 
 =head2 parameters
 
-Returns the object parameters from the configured parameters provider. This is
-the same as L</augmentation_for> except it picks the C<parameters> service
-instead of asking for a component name.
+=head2 params_hash
 
-If the parameters service is well-behaved it will return another DBIx::Class
-result.
+This returns a hashref of all parameters defined against this object. This is
+done by finding all brains wearing the C<parameters> hat and asking them.
+
+C<params_hash> is supplied as an alias for backward compatibility.
 
 =cut
 
 sub parameters {
     my $self = shift;
 
-    OpusVL::FB11::Hive
-        ->service('parameters')
-        ->get_augmented_data($self)
+    my $combined = {};
+    for my $hat ( OpusVL::FB11::Hive->hats('parameters') ) {
+        my $current = $hat->get_augmented_data($self);
+        next unless $current;
+        $combined = {
+            %$combined,
+            %$current
+        }
+    }
+
+    return $combined;
 }
+
+*params_hash = \&parameters;
 
 =head2 methods_for_delegation
 

--- a/lib/auto/OpusVL/FB11/root/templates/fb11/admin/users/show_user.tt
+++ b/lib/auto/OpusVL/FB11/root/templates/fb11/admin/users/show_user.tt
@@ -94,6 +94,13 @@
       [% form.render | none %]
     </div>
 
+    [% IF params_form %]
+      <div class="col-sm-6 fb11-card">
+        <h1>Parameters for <strong>[% thisuser.name %]</strong></h1>
+        [% params_form.render | none %]
+      </div>
+    [% END %]
+
     [% IF c.config.enable_avatar == 1 %]
       <div class="col-sm-6">
         <div class="panel panel-default">


### PR DESCRIPTION
It's too early to have this kind of magic.  If code relies on it, then we decide later it breaks things (e.g. if we decide a Hive shouldn't be a singleton after all), we're in with a hard job of altering all the existing code.  Besides this is probably redundant once we're building the hives from YAML.

We can always re-introduce the woo later if it turns out it will be useful and we have proven the system's APIs such that we won't ever want to de-singletonise the hive, but lets keep it manual for now.