### PR TITLE
Remove auto-registration of Brains into the hive.

### DIFF
--- a/lib/OpusVL/FB11/Role/Brain.pm
+++ b/lib/OpusVL/FB11/Role/Brain.pm
@@ -206,9 +206,7 @@ sub provided_services {}
 
 =head2 register_self
 
-Call this if your Brain isn't a normal Moose class. By default, the Role hooks
-into BUILD and registers itself after construction, but packages are not
-required to provide a C<sub new>, such as DBIx::Class::Schema.
+Syntactic sugar for self-installing into the hive.
 
 =cut
 
@@ -216,9 +214,5 @@ sub register_self {
     my $self = shift;
     OpusVL::FB11::Hive->register_brain($self);
 }
-
-# This ensures there *is* a BUILD, and has no effect if there already is one.
-sub BUILD {}
-after BUILD => \&register_self;
 
 1;


### PR DESCRIPTION
Main objection is the fact it just looks odd to instantiate something in void context and rely on things magically happening in the background.

It's too early to have this kind of magic.  If code relies on it, then we decide later it breaks things (e.g. if we decide a Hive shouldn't be a singleton after all), we're in with a hard job of altering all the existing code.  Besides this is probably redundant once we're building the hives from YAML.

We can always re-introduce the woo later if it turns out it will be useful and we have proven the system's APIs such that we won't ever want to de-singletonise the hive, but lets keep it manual for now.

Note hive.t still passes without any modifications.